### PR TITLE
chore: add pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,27 @@
+name: "Pull Request"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+env:
+  GO_VERSION: 1.23
+jobs:
+  lint-test:
+    name: "Lint and Test"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Setup Go"
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: "Golang CI Lint"
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+      - name: "Run Tests"
+        run: go test -v ./...


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate linting and testing for pull requests. The workflow is designed to run on every pull request event and includes steps for setting up the Go environment, running lint checks, and executing tests.

Key changes:

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R1-R27): Added a new workflow configuration to automate linting and testing for pull requests. This includes setting the Go version to 1.23, using the latest Ubuntu runner, and integrating `golangci-lint` for linting and `go test` for running tests.